### PR TITLE
Add water heater in supported devices

### DIFF
--- a/custom_components/rointe/const.py
+++ b/custom_components/rointe/const.py
@@ -15,7 +15,7 @@ CONF_INSTALLATION = "rointe_installation"
 
 ROINTE_MANUFACTURER = "Rointe"
 
-ROINTE_SUPPORTED_DEVICES = ["radiator", "towel", "therm", "radiatorb", "oval_towel"]
+ROINTE_SUPPORTED_DEVICES = ["radiator", "towel", "therm", "radiatorb", "oval_towel", "acs"]
 
 CMD_SET_TEMP = "cmd_set_temp"
 CMD_SET_PRESET = "cmd_set_preset"


### PR DESCRIPTION
I have a Series-D water heater and this change works for me on Home Assistant.
Although I can't get the consumption or other more specific things, it's okay with me to turn it on or off, change the temperature, and know the temperature it has. I would appreciate it very much if you would include this change here.

Furthermore, if you need to test anything else for this kind of device, please let me know.

Thanks