### PR TITLE
fix deprecated constants (#12)

### DIFF
--- a/custom_components/rointe/climate.py
+++ b/custom_components/rointe/climate.py
@@ -16,7 +16,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -80,7 +80,7 @@ class RointeHaClimate(RointeRadiatorEntity, ClimateEntity, ABC):
     @property
     def temperature_unit(self) -> str:
         """Temperature unit."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def target_temperature(self) -> float:

--- a/custom_components/rointe/sensor_descriptions.py
+++ b/custom_components/rointe/sensor_descriptions.py
@@ -1,4 +1,5 @@
 """Sensor descriptions for Rointe."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -10,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT, TEMP_CELSIUS
+from homeassistant.const import UnitOfEnergy, UnitOfPower, UnitOfTemperature
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
 
@@ -38,7 +39,7 @@ SENSOR_DESCRIPTIONS = [
         key="current_temperature",
         name="Current Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda radiator: radiator.temp_probe,
         last_reset_fn=lambda radiator: None,
@@ -48,7 +49,7 @@ SENSOR_DESCRIPTIONS = [
         key="energy",
         name="Energy Consumption",
         device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda radiator: radiator.energy_data.kwh
@@ -63,7 +64,7 @@ SENSOR_DESCRIPTIONS = [
         key="power",
         name="Effective Power",
         device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda radiator: radiator.energy_data.effective_power


### PR DESCRIPTION
trivial change to remove warnings about deprecated energy, temperature and power constants.
See https://github.com/tggm/rointe-hacs/issues/12

Requires 2022.11 version, which is already the required version as per `hacs.json`:
https://developers.home-assistant.io/blog/2022/10/26/new-unit-enumerators/